### PR TITLE
Feature: Allow ErrorAction to properly handle errors

### DIFF
--- a/dbops.psm1
+++ b/dbops.psm1
@@ -116,6 +116,25 @@ Register-PSFConfigValidation -Name "connectionType" -ScriptBlock {
     return $Result
 }
 
+Register-PSFConfigValidation -Name "errorAction" -ScriptBlock {
+    Param (
+        $Value
+    )
+    $Result = New-Object PSObject -Property @{
+        Success = $True
+        Value   = $null
+        Message = ""
+    }
+    try {
+        $Result.Value = [String][System.Management.Automation.ActionPreference]$Value
+    }
+    catch {
+        $Result.Message = $_.Exception.Message
+        $Result.Success = $False
+    }
+    return $Result
+}
+
 Register-PSFConfigValidation -Name "tokenRegex" -ScriptBlock {
     Param (
         $Value
@@ -175,6 +194,10 @@ Set-PSFConfig -FullName dbops.package.slim -Value $false -Validation bool -Initi
 Set-PSFConfig -FullName dbops.config.variabletoken -Value "\#\{(token)\}" -Validation tokenRegex -Initialize -Description "Variable replacement token. Regex string that will be replaced with values from -Variables parameters. Default: \#\{(token)\}"
 $dotNet = try { dotnet --version } catch { $null }
 Set-PSFConfig -FullName dbops.runtime.dotnetversion -Value ($dotNet -as [version]) -Description "Current dotnet runtime." -Hidden
+Set-PSFConfig -FullName dbops.ErrorActionPreference -Value Stop -Initialize -Description "Module ErrorAction default value" -Validation errorAction
+
+# Module-wide ErrorAction preference
+$ErrorActionPreference = Get-PSFConfigValue -FullName dbops.ErrorActionPreference
 
 # extensions for SMO
 $typeData = Get-TypeData -TypeName 'Microsoft.SqlServer.Management.Smo.Database'

--- a/functions/Invoke-DBOQuery.ps1
+++ b/functions/Invoke-DBOQuery.ps1
@@ -427,7 +427,7 @@ function Invoke-DBOQuery {
         }
         catch {
             # don't really need anything else here
-            throw $_
+            Write-Error $_
         }
         finally {
             # close the connection even when interrupted by Ctrl+C

--- a/internal/classes/DBOpsDeploymentStatus.class.ps1
+++ b/internal/classes/DBOpsDeploymentStatus.class.ps1
@@ -10,6 +10,7 @@ class DBOpsDeploymentStatus {
     [System.Nullable[datetime]] $StartTime
     [System.Nullable[datetime]] $EndTime
     [string[]] $DeploymentLog
+    [string] $ErrorScript
 
     DBOpsDeploymentStatus() {
         Add-Member -InputObject $this -MemberType ScriptProperty -Name Duration -Value {

--- a/internal/functions/Invoke-Deployment.ps1
+++ b/internal/functions/Invoke-Deployment.ps1
@@ -134,7 +134,7 @@
             if (!$Status.Successful) {
                 # Throw output error if unsuccessful
                 if ($Status.Error) {
-                    if ($Status.ErrorScript) {
+                    if ($upgradeResult.errorScript) {
                         $Status.ErrorScript = $upgradeResult.errorScript.Name
                     }
                     throw $Status.Error
@@ -352,17 +352,12 @@
                 }
             }
             catch {
-                throw $_
+                Write-Error $_
             }
             finally {
                 $status.EndTime = [datetime]::Now
             }
-            if ($status.Successful) {
-                return $status
-            }
-            else {
-                return $status | Select-PSFObject -ShowProperty SourcePath, SqlInstance, Database, Successful, Error, Duration, ErrorScript
-            }
+            return $status
         }
     }
     end { }

--- a/internal/functions/Invoke-Deployment.ps1
+++ b/internal/functions/Invoke-Deployment.ps1
@@ -134,6 +134,9 @@
             if (!$Status.Successful) {
                 # Throw output error if unsuccessful
                 if ($Status.Error) {
+                    if ($Status.ErrorScript) {
+                        $Status.ErrorScript = $upgradeResult.errorScript.Name
+                    }
                     throw $Status.Error
                 }
                 else {
@@ -353,7 +356,12 @@
             }
             finally {
                 $status.EndTime = [datetime]::Now
-                $status
+            }
+            if ($status.Successful) {
+                return $status
+            }
+            else {
+                return $status | Select-PSFObject -ShowProperty SourcePath, SqlInstance, Database, Successful, Error, Duration, ErrorScript
             }
         }
     }

--- a/internal/xml/dbops.format.ps1xml
+++ b/internal/xml/dbops.format.ps1xml
@@ -108,6 +108,9 @@
                     <ListItem>
                         <PropertyName>Duration</PropertyName>
                     </ListItem>
+                    <ListItem>
+                        <PropertyName>ErrorScript</PropertyName>
+                    </ListItem>
                 </ListItems>
             </ListEntry>
         </ListEntries>

--- a/tests/Install-DBOScript.Tests.ps1
+++ b/tests/Install-DBOScript.Tests.ps1
@@ -474,6 +474,23 @@ Describe "Install-DBOScript integration tests" -Tag $commandName, IntegrationTes
             $errorObject | Should Not BeNullOrEmpty
             $errorObject.Exception.Message | Should Be "There is already an object named 'a' in the database."
         }
+        It "Should return failure results with SilentlyContinue" {
+            $testResults = Install-DBOScript -Absolute -Path $tranFailScripts -SchemaVersionTable $logTable -DeploymentMethod NoTransaction @connParams -ErrorAction SilentlyContinue
+            $testResults | Should -Not -Be $null
+            $testResults.Successful | Should -Be $false
+            $testResults.SqlInstance | Should Be $script:mssqlInstance
+            $testResults.Database | Should Be $newDbName
+            $testResults.SourcePath | Should Be $v1scripts
+            $testResults.ConnectionType | Should Be 'SQLServer'
+            $testResults.Configuration.SchemaVersionTable | Should BeNullOrEmpty
+            $testResults.Error.Message | Should Be "There is already an object named 'a' in the database."
+            $testResults.ErrorScript | Should -Be (Resolve-Path $v1scripts).Path
+            $testResults.Scripts.Name | Should Be (Resolve-Path $v1scripts).Path
+            $testResults.Duration.TotalMilliseconds | Should -BeGreaterOrEqual 0
+            $testResults.StartTime | Should Not BeNullOrEmpty
+            $testResults.EndTime | Should Not BeNullOrEmpty
+            $testResults.EndTime | Should -BeGreaterOrEqual $testResults.StartTime
+        }
         It "should not deploy anything after throwing an error" {
             #Running package
             try {

--- a/tests/Invoke-Deployment.Tests.ps1
+++ b/tests/Invoke-Deployment.Tests.ps1
@@ -9,6 +9,7 @@ if (!$Batch) {
     # Is not a part of the global batch => import module
     #Explicitly import the module for testing
     Import-Module "$here\..\dbops.psd1" -Force; Get-DBOModuleFileList -Type internal | ForEach-Object { . $_.FullName }
+    $ErrorActionPreference = 'Stop'
 }
 else {
     # Is a part of a batch, output some eye-catching happiness

--- a/tests/Invoke-Deployment.Tests.ps1
+++ b/tests/Invoke-Deployment.Tests.ps1
@@ -9,13 +9,13 @@ if (!$Batch) {
     # Is not a part of the global batch => import module
     #Explicitly import the module for testing
     Import-Module "$here\..\dbops.psd1" -Force; Get-DBOModuleFileList -Type internal | ForEach-Object { . $_.FullName }
-    $ErrorActionPreference = 'Stop'
 }
 else {
     # Is a part of a batch, output some eye-catching happiness
     Write-Host "Running $commandName tests" -ForegroundColor Cyan
 }
 
+$ErrorActionPreference = 'Stop'  # Needed for non-public commands
 . "$here\constants.ps1"
 
 $workFolder = Join-PSFPath -Normalize "$here\etc" "$commandName.Tests.dbops"


### PR DESCRIPTION
Users should now be able to use 
```
$result = Install-DBOScript ... -ErrorAction SilentlyContinue
```
to retrieve the result object even in case of script failure.

Also adds a new property `ErrorScript` to the output object.

Closes #134