### PR TITLE
Check for empty file when computing hash

### DIFF
--- a/internal/classes/DBOps.class.ps1
+++ b/internal/classes/DBOps.class.ps1
@@ -1093,6 +1093,8 @@ class DBOpsFile : DBOps {
     [void] RebuildHash() {
         if ($this.Length -gt 0) {
             $this.Hash = [DBOpsHelper]::ToHexString([Security.Cryptography.HashAlgorithm]::Create("MD5").ComputeHash($this.ByteArray))
+        } else {
+            $this.ThrowException("Hash cannot be computed, file is empty: $($this.Name)", 'InvalidData')
         }
     }
     #Verify that hash is valid

--- a/tests/common/DBOpsFile.class.Tests.ps1
+++ b/tests/common/DBOpsFile.class.Tests.ps1
@@ -154,6 +154,10 @@ Describe "DBOpsFile class tests" -Tag UnitTests {
             $file.RebuildHash()
             $file.Hash | Should -Be $oldHash
         }
+        It "should test RebuildHash method with empty file" {
+            $emptyFile = New-Item $workFolder\emptyfile.sql -ItemType File
+            { [DBOpsFile]::new($emptyFile, 'emptyfile.sql', $true) } | Should -Throw
+        }
         It "should test ValidateHash method" {
             $hash = $file.Hash
             { $file.ValidateHash('foo') } | Should -Throw 'File cannot be loaded, hash mismatch*'


### PR DESCRIPTION
Pull request in response to [issue  #167](https://github.com/dataplat/dbops/issues/167).

If I see this correctly, adding the else-statement to the RebuildHash() function is the only place needed to fix this. A simple test was successfull:

```
New-DboPackage "Package.zip" -ScriptPath "empty_file.sql"
Hash cannot be computed, file is empty: empty_file.sql
In C:\Program Files\WindowsPowerShell\Modules\PSFramework\1.9.310\PSFramework.psm1:5644 Zeichen:23
+         if (-not $Cmdlet) { throw $records[0] }
+                             ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (2.sql:DBOpsFile) [], Exception
    + FullyQualifiedErrorId : dbops_DBOpsFile

Add-DboBuild "Package.zip" -ScriptPath "empty_file.sql"
Hash cannot be computed, file is empty: empty_file.sql
In C:\Program Files\WindowsPowerShell\Modules\PSFramework\1.9.310\PSFramework.psm1:5644 Zeichen:23
+         if (-not $Cmdlet) { throw $records[0] }
+                             ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (2.sql:DBOpsFile) [], Exception
    + FullyQualifiedErrorId : dbops_DBOpsFile
```